### PR TITLE
Fix video cube textures lost on re-render

### DIFF
--- a/src/components/VideoCube.tsx
+++ b/src/components/VideoCube.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 
@@ -60,7 +60,11 @@ export default function VideoCube({ sources }: VideoCubeProps) {
     };
   }, [sources]);
 
-  const materials = Array.from({ length: 6 }, () => new THREE.MeshBasicMaterial({ color: 'black' }));
+  // create the materials once so video textures are not lost on re-render
+  const materials = useMemo(
+    () => Array.from({ length: 6 }, () => new THREE.MeshBasicMaterial({ color: 'black' })),
+    []
+  );
 
   return (
     <mesh


### PR DESCRIPTION
## Summary
- ensure `VideoCube` materials are only created once with `useMemo`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_68489c479f4883229b581268b9fcd810