### PR TITLE
Add timeline list and hover animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,18 @@ export default function App() {
           setSelected(event);
         }}
       />
+      <div style={{ padding: '2rem' }}>
+        <Timeline events={events} onSelect={(id) => {
+          const event = events.find((e) => e.id === id) || null;
+          setSelected(event);
+        }} />
+      </div>
       {selected && (
         <div className="modal" onClick={() => setSelected(null)}>
           <Timeline.Detail event={selected} />
         </div>
       )}
-    </div>
-  );
+      </div>
+    );
+}
 

--- a/src/components/TimelineCube.tsx
+++ b/src/components/TimelineCube.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import { Mesh } from 'three';
+import { animated, useSpring } from '@react-spring/three';
 import type { TimelineEvent } from './Timeline';
 
 interface TimelineCubeProps {
@@ -13,6 +14,7 @@ interface TimelineCubeProps {
 export default function TimelineCube({ event, position, onSelect }: TimelineCubeProps) {
   const ref = useRef<Mesh>(null!);
   const [hovered, setHovered] = useState(false);
+  const { scale } = useSpring({ scale: hovered ? 1.2 : 1, config: { tension: 170, friction: 12 } });
 
   useFrame(() => {
     if (ref.current) {
@@ -21,19 +23,29 @@ export default function TimelineCube({ event, position, onSelect }: TimelineCube
   });
 
   return (
-    <mesh
+    <animated.mesh
       ref={ref}
       position={position}
+      scale={scale}
       onClick={() => onSelect(event.id)}
       onPointerOver={() => setHovered(true)}
       onPointerOut={() => setHovered(false)}
     >
-      <boxGeometry args={[1, 1, 1]} />
+      {hovered ? (
+        <sphereGeometry args={[0.75, 32, 32]} />
+      ) : (
+        <boxGeometry args={[1, 1, 1]} />
+      )}
       <meshStandardMaterial color={hovered ? 'orange' : 'hotpink'} />
-      <Html center distanceFactor={6} style={{ pointerEvents: 'none', fontSize: '0.5rem', color: 'white' }}>
+      <Html
+        position={[0, -1.2, 0]}
+        center
+        distanceFactor={6}
+        style={{ pointerEvents: 'none', fontSize: '0.5rem', color: 'white' }}
+      >
         {event.title}
       </Html>
-    </mesh>
+    </animated.mesh>
   );
 }
 


### PR DESCRIPTION
## Summary
- add sphere animation to timeline cubes
- show a simple list of events under the 3D scene

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684bd04495c0832299f3804e9a67de79